### PR TITLE
Add standard development .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# General OS generated files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+.Python
+env/
+venv/
+.venv/
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Node artifacts
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Editor directories
+.vscode/
+.idea/
+
+# Logs
+*.log
+
+


### PR DESCRIPTION
## Summary
- add .gitignore with common OS, Python, Node, and editor artifacts

## Testing
- `git status --short`